### PR TITLE
update(composer.json): bump symfony/var-exporter version compatibility to ||^8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,12 +30,12 @@
     "require": {
         "php": "^8.1",
         "nikic/php-parser": "^4.16||^5",
-        "symfony/var-exporter": "^4||^5||^6||^7",
+        "symfony/var-exporter": "^4||^5||^6||^7||^8",
         "phpunit/phpunit": "^10||^11||^12||^13",
         "composer-runtime-api": "*"
     },
     "require-dev": {
-        "symfony/var-dumper": "^6||^7"
+        "symfony/var-dumper": "^6||^7||^8"
     },
     "scripts": {
         "test:unit": "phpunit tests"


### PR DESCRIPTION
Extension of support for Symfony version 8